### PR TITLE
Adding gulp task to automate Version bumping and release tagging

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,9 @@ var ts = require('gulp-typescript');
 var sourcemaps = require('gulp-sourcemaps');
 var tslint = require("gulp-tslint");
 var minify = require('gulp-minify');
+var git = require('gulp-git');
+var versionBump = require('gulp-bump')
+var tagVersion = require('gulp-tag-version');
 
 gulp.task("build", function() {
     return gulp.src([
@@ -31,3 +34,22 @@ gulp.task("build", function() {
         .pipe(minify())
         .pipe(gulp.dest('distrib'));
 });
+
+// We dont want to release anything without successful build. So build task is dependency for these tasks.
+gulp.task('patchRelease', ['build'], function() { return BumpVersionTagAndCommit('patch'); })
+gulp.task('featureRelease', ['build'], function() { return BumpVersionTagAndCommit('minor'); })
+gulp.task('majorRelease', ['build'], function() { return BumpVersionTagAndCommit('major'); })
+gulp.task('preRelease', ['build'], function() { return BumpVersionTagAndCommit('prerelease'); })
+
+function BumpVersionTagAndCommit(versionType) {
+    return gulp.src(['./package.json'])
+        // bump the version numbr
+        .pipe(versionBump({type:versionType}))
+        // save it back to filesystem 
+        .pipe(gulp.dest('./'))
+        // commit the changed version number 
+        .pipe(git.commit('Bumping package version'))
+        // tag it in the repository
+        .pipe(tagVersion());
+}
+ 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,11 @@
   "license": "ISC",
   "devDependencies": {
     "gulp": "^3.9.1",
+    "gulp-bump": "^2.7.0",
+    "gulp-git": "^2.2.0",
     "gulp-minify": "0.0.15",
     "gulp-sourcemaps": "^2.6.0",
+    "gulp-tag-version": "^1.3.0",
     "gulp-tslint": "^8.0.0",
     "gulp-typescript": "^3.1.6",
     "tslint": "^5.1.0",
@@ -36,6 +39,10 @@
   },
   "scripts": {
     "prepublishOnly": "npm install & gulp build",
-    "build": "npm install & gulp build"
+    "build": "npm install & gulp build",
+    "patchRelease": "npm install & gulp patchRelease",
+    "featureRelease": "npm install & gulp featureRelease",
+    "majorRelease": "npm install & gulp majorRelease",
+    "preRelease": "npm install & gulp preRelease"
   }
 }


### PR DESCRIPTION
This will provide us a way to bump the version and tag the version change to the commit. Tagging will give us a nice way to sync to version or view our version history.
For more details about tagging refer to https://git-scm.com/book/en/v2/Git-Basics-Tagging.

Recommend to run either of these commands before publishing npm packages.
npm run <patchRelease/featureRelease/majorRelease/preRelease>
gulp <patchRelease/featureRelease/majorRelease/preRelease>
