### PR TITLE
Fix Promise assign error when module importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microsoft-speech-browser-sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Microsoft Speech SDK for browsers",
   "main": "distrib/speech.browser.sdk-min.js",
   "types": "distrib/speech.browser.sdk.d.ts",

--- a/src/common.browser/FileAudioSource.ts
+++ b/src/common.browser/FileAudioSource.ts
@@ -52,7 +52,7 @@ export class FileAudioSource implements IAudioSource {
         this.file = file;
     }
 
-    public TurnOn = (): Promise<boolean> => {
+    public TurnOn = (): Promise<any> => {
         if (typeof FileReader === "undefined") {
             const errorMsg = "Browser does not support FileReader.";
             this.OnEvent(new AudioSourceErrorEvent(errorMsg, "")); // initialization error - no streamid at this point


### PR DESCRIPTION
This PR resolve the following error when importing module `import * as Bing from 'microsoft-speech-browser-sdk/Speech.Browser.Sdk'`:

```
Type 'Promise<{}>' is not assignable to type 'Promise<void>'
```

Please release this as a new version.