### PR TITLE
Fix TSLint errors

### DIFF
--- a/src/sdk/speech/RecognizerConfig.ts
+++ b/src/sdk/speech/RecognizerConfig.ts
@@ -37,7 +37,7 @@ export class RecognizerConfig {
         return this.language;
     }
 
-    public get Format(): SpeechResultFormat{
+    public get Format(): SpeechResultFormat {
         return this.format;
     }
 
@@ -77,7 +77,7 @@ export class SpeechConfig {
         });
     }
 
-    public get Context(): Context{
+    public get Context(): Context {
         return this.context;
     }
 


### PR DESCRIPTION
Simple ones, results of including `tslint` in the project, missing white space in the functions stamps.

```bash
ERROR: /Users/piotrblazejewicz/git/SpeechToText-WebSockets-Javascript/src/sdk/speech/RecognizerConfig.ts[40, 44]: missing whitespace
ERROR: /Users/piotrblazejewicz/git/SpeechToText-WebSockets-Javascript/src/sdk/speech/RecognizerConfig.ts[80, 34]: missing whitespace
```
Intersting, it does not occur when using `gulp build`, but when running standalone `tslint` linter.

Thanks!