### PR TITLE
Fix case on typings file (for build on Linux)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.12",
   "description": "Microsoft Speech SDK for browsers",
   "main": "distrib/Speech.Browser.Sdk.js",
-  "types": "distrib/speech.browser.sdk.d.ts",
+  "types": "distrib/Speech.Browser.Sdk.d.ts",
   "keywords": [
     "microsoft",
     "speech",


### PR DESCRIPTION
When building an app that uses this module on a case-sensitive
filesystem, such as those used on most Linux systems, the typings file
listed in package.json is not found. The file actually exists, but has
the wrong case.

This commit changes the typings to refer to Speech.Browser.Sdk.d.ts, not
its lower-cased version, so that it will be found correctly on Linux.

Fixes #72