### PR TITLE
Get NPM scripts to work cross-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "microsoft-speech-browser-sdk",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "webpack-stream": "^4.0.0"
   },
   "scripts": {
-    "prepublishOnly": "npm install & gulp build",
-    "build": "npm install & gulp build",
-    "bundle": "npm install & gulp bundle",
-    "patchRelease": "npm install & gulp patchRelease",
-    "featureRelease": "npm install & gulp featureRelease",
-    "majorRelease": "npm install & gulp majorRelease",
-    "preRelease": "npm install & gulp preRelease"
+    "prepublishOnly": "npm install && gulp build",
+    "build": "npm install && gulp build",
+    "bundle": "npm install && gulp bundle",
+    "patchRelease": "npm install && gulp patchRelease",
+    "featureRelease": "npm install && gulp featureRelease",
+    "majorRelease": "npm install && gulp majorRelease",
+    "preRelease": "npm install && gulp preRelease"
   }
 }


### PR DESCRIPTION
These scripts were broken on macOS / Linux:
In Windows CMD shells, single `&` means "run A then B", like a semicolon.
In Bash shells, single `&` means "run A in the background."

In both shells, double `&&` means "run A then run B if A was successful."  I believe this is what we want.  Tested in PowerShell as well.

A possibly better fix would be to move the `npm install` step to the Gulpfile so it doesn't have to be repeated every time, but this is the quicker fix in line with the current design.