### PR TITLE
Updated SDK.Recognizer.Create to SDK.CreateRecognizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ function RecognizerSetup(SDK, recognitionMode, language, format, subscriptionKey
     // Alternatively use SDK.CognitiveTokenAuthentication(fetchCallback, fetchOnExpiryCallback) for token auth
     let authentication = new SDK.CognitiveSubscriptionKeyAuthentication(subscriptionKey);
 
-    return SDK.Recognizer.Create(recognizerConfig, authentication);
+    return SDK.CreateRecognizer(recognizerConfig, authentication);
 }
 
 function RecognizerStart(SDK, recognizer) {


### PR DESCRIPTION
Compared to the [sample scripts](https://github.com/Azure-Samples/SpeechToText-WebSockets-Javascript/blob/477067fe264159e7ccbd233a01015f9ea03a6d06/samples/browser/Sample.html#L197), `SDK.CreateRecognizer` is the correct way to create the recognizer