### PR TITLE
Match against lowercase path in ReceiveMessage

### DIFF
--- a/src/sdk/speech/Recognizer.ts
+++ b/src/sdk/speech/Recognizer.ts
@@ -193,7 +193,7 @@ export class Recognizer {
                         case "turn.start":
                             requestSession.OnServiceTurnStartResponse(JSON.parse(connectionMessage.TextBody));
                             break;
-                        case "speech.startDetected":
+                        case "speech.startdetected":
                             requestSession.OnServiceSpeechStartDetectedResponse(JSON.parse(connectionMessage.TextBody));
                             break;
                         case "speech.hypothesis":


### PR DESCRIPTION
Hello there,

I haven't tried running the code, but while looking over it I noticed that the code in `ReceiveMessage` doesn't use lowercase when matching for `speech.startDetected`, which means it can never emit that message and will instead silently drop it (since it compares against `connectionMessage.Path.toLowerCase()`)